### PR TITLE
Fix flatpak

### DIFF
--- a/roles/install_general_software/tasks/main.yml
+++ b/roles/install_general_software/tasks/main.yml
@@ -42,14 +42,14 @@
     name: "flathub"
     state: "present"
     flatpakrepo_url: "https://flathub.org/repo/flathub.flatpakrepo"
-    method: "user"
+    method: "system"
 
 - name: "Initialize flathub"
   community.general.flatpak_remote:
     name: "flathub"
     state: "present"
     flatpakrepo_url: "https://flathub.org/repo/flathub.flatpakrepo"
-    method: "user"
+    method: "system"
 
 - name: "Install flatpak packages"
   community.general.flatpak:


### PR DESCRIPTION
Fixes #13
- change method to system because we have only one user
- if method user is used currently it will been shown because root installs the packages